### PR TITLE
changes default views from NPR sizes to STLPR-Grove sizes

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "express": "^4.16.4",
     "fsevents": "^2.0.7",
     "googleapis": "^35.0.0",
+    "jquery": "^3.5.1",
     "less": "^3.8.1",
     "lodash.escape": "^4.0.1",
     "lodash.template": "^4.4.0",

--- a/server/static/style.css
+++ b/server/static/style.css
@@ -316,9 +316,9 @@ select {
   width: 100%;
 }
 
-.preview-page .preview-container[data-width="sidebar"] { width: 180px }
+.preview-page .preview-container[data-width="sidebar"] { width: 330px }
 .preview-page .preview-container[data-width="mobile"] { width: 360px }
-.preview-page .preview-container[data-width="desktop"] { width: 730px }
+.preview-page .preview-container[data-width="desktop"] { width: 700px }
 .preview-page .preview-container[data-width="fluid"] { border-width: 2px 0; }
 
 .preview-page .metadata {

--- a/server/templates/parentPage.html
+++ b/server/templates/parentPage.html
@@ -21,11 +21,8 @@
 
     <select class="breakpoint" aria-label="Preview width">
       <option value="mobile" selected>Mobile (360px)</option>
-      <option value="desktop">Desktop (663px)</option>
-      <option value="desktop-sidebar">Desktop + Sidebar (678px)</option>
-      <option value="inset">Inset (317px)</option>
-      <option value="inset-sidebar">Inset + Sidebar (324px)</option>
-      <option value="full-width">XL (1010px)</option>
+      <option value="desktop">Desktop (700px)</option>
+      <option value="sidebar">Sidebar (330px)</option>
       <option value="fluid">Fluid</option>
     </select>
 


### PR DESCRIPTION
Removes Desktop + Sidebar, Inset, Inset + Sidebar, XL views from dg-next app parentPage. Updates mobile and desktop sizes to match Grove breakpoints. Adds sidebar view with Grove breakpoints. 